### PR TITLE
setting default spells in magic.core the easy way

### DIFF
--- a/magic/core.clj
+++ b/magic/core.clj
@@ -935,3 +935,14 @@
   (let [form (list* 'fn name args body)]
     `(def ~name
        ~(compile-fn form))))
+
+;; load up spells
+;; cyclic, but meh
+(require
+  'magic.spells.intrinsics
+  'magic.spells.lift-vars)
+
+(alter-var-root #'*spells*
+  (constantly
+    [magic.spells.intrinsics/intrinsics
+     magic.spells.lift-vars/lift-vars]))


### PR DESCRIPTION
I'm having some deep misgivings about `magic.core/*spells*` as a user-facing API, but while we're working that out we can just internally set it to use intrinsics and var-lifting