### PR TITLE
convertable -> convertible

### DIFF
--- a/magic/analyzer/types.clj
+++ b/magic/analyzer/types.clj
@@ -57,7 +57,7 @@
     (resolve t)))
 
 ;; TODO warn on truncate?
-(defn convertable? [from to]
+(defn convertible? [from to]
   (or (and (nil? from) (nil? to))
       (= from to)
       (and (nil? from) (not (.IsValueType to)))
@@ -83,7 +83,7 @@
                  (let [sig-params (map #(.ParameterType %) (.GetParameters sig))]
                    (and (= (count params)
                            (count sig-params))
-                        (every? true? (map convertable? params sig-params))))))
+                        (every? true? (map convertible? params sig-params))))))
        (sort-by specificity)
        reverse))
 
@@ -101,7 +101,7 @@
     (and (= (count args)
             (count params))
          (->> (map
-                #(convertable? %1 %2)
+                #(convertible? %1 %2)
                 (map #(.ParameterType %) params)
                 args)
               (remove identity)


### PR DESCRIPTION
Lax spelling bespeaks lax morals, and begets societal decline.

https://english.stackexchange.com/questions/300821/why-convertible-and-not-convertable#answer-300827

![image](https://cloud.githubusercontent.com/assets/451342/25561803/35e05a56-2d41-11e7-911a-c1b3133ef50f.png)

![image](https://cloud.githubusercontent.com/assets/451342/25561853/42f789b6-2d42-11e7-93fd-255b6c0c9483.png)
