### PR TITLE
adding options to compile-namespace

### DIFF
--- a/src/magic/api.clj
+++ b/src/magic/api.clj
@@ -236,7 +236,7 @@
                                              (compile-namespace roots lib opts)
                                              (dosync
                                                (commute -loaded-libs conj lib))))]
-       (compile-file roots path (munge (str namespace)))))))
+       (compile-file roots path (munge (str namespace)) opts)))))
 
 (def version "0.0-alpha")
 

--- a/src/magic/api.clj
+++ b/src/magic/api.clj
@@ -153,7 +153,7 @@
                                                 ;; cant with-redefs because clojure.core/load bottoms out in
                                                 ;; clojure.lang.RT/load
                                                 (if-let [path' (find-file roots path)]
-                                                  (compile-file roots path' path)
+                                                  (compile-file roots path' path opts)
                                                   (throw (Exception. (str "Could not find " path ", roots " roots))))))))))]
                    (.Invoke (.GetMethod expr-type "eval") nil empty-args))
                  (recur (read-1) (inc i))))

--- a/src/magic/api.clj
+++ b/src/magic/api.clj
@@ -112,51 +112,54 @@
    :features #{:cljr}})
 
 (defn load-file
-  [roots path ctx]
-  (let [file (System.IO.File/OpenText path)]
-    (try
-      (let [rdr (LineNumberingTextReader. file)
-            read-1 (fn [] (try (read read-options rdr) (catch Exception _ nil)))]
-        (loop [expr (read-1) i 0]
-          (if expr
-            (do
-              (println (-> expr (trim 30)) (str *ns*) (ns-aliases *ns*))
-              (let [expr-name (u/gensym "<magic>expr")
-                    expr-type (.DefineType magic.emission/*module* expr-name abstract-sealed)
-                    expr-method (.DefineMethod expr-type "eval" public-static)
-                    expr-ilg (.GetILGenerator expr-method)
-                    ctx' (assoc ctx
-                                ::il/type-builder expr-type
-                                ::il/method-builder expr-method
-                                ::il/ilg expr-ilg)]
-                (il/emit! ctx'
-                          [(-> expr
-                               ana/analyze
-                               magic/compile)
-                           [(il/pop)
-                            (il/ret)]])
-                (il/emit! ctx (il/call expr-method))
-                (.CreateType expr-type)
-                (with-redefs [load (fn magic-load-fn [& paths]
-                                     ;; copied from core.clj
-                                     (doseq [^String path paths]
-                                       (let [^String path (if (.StartsWith path "/")
-                                                            path
-                                                            (str (root-directory (ns-name *ns*)) \/ path))]
-                                         (check-cyclic-dependency path)
-                                         (when-not (= path (first *pending-paths*))
-                                           (binding [*pending-paths* (conj *pending-paths* path)]
-                                             (let [path (.Substring path 1)]
-                                               ;; cant with-redefs because clojure.core/load bottoms out in
-                                               ;; clojure.lang.RT/load
-                                               (if-let [path' (find-file roots path)]
-                                                 (compile-file roots path' path)
-                                                 (throw (Exception. (str "Could not find " path ", roots " roots))))))))))]
-                  (.Invoke (.GetMethod expr-type "eval") nil empty-args))
-                (recur (read-1) (inc i))))
-            (.Close rdr))))
-      (finally
-        (.Close file)))))
+  ([roots path ctx]
+   (load-file roots path ctx nil))
+  ([roots path ctx opts]
+   (let [file (System.IO.File/OpenText path)]
+     (try
+       (let [rdr (LineNumberingTextReader. file)
+             read-1 (fn [] (try (read read-options rdr) (catch Exception _ nil)))]
+         (loop [expr (read-1) i 0]
+           (if expr
+             (do
+               (when-not (:suppress-print-forms opts)
+                 (println (-> expr (trim 30)) (str *ns*) (ns-aliases *ns*)))
+               (let [expr-name (u/gensym "<magic>expr")
+                     expr-type (.DefineType magic.emission/*module* expr-name abstract-sealed)
+                     expr-method (.DefineMethod expr-type "eval" public-static)
+                     expr-ilg (.GetILGenerator expr-method)
+                     ctx' (assoc ctx
+                            ::il/type-builder expr-type
+                            ::il/method-builder expr-method
+                            ::il/ilg expr-ilg)]
+                 (il/emit! ctx'
+                   [(-> expr
+                        ana/analyze
+                        magic/compile)
+                    [(il/pop)
+                     (il/ret)]])
+                 (il/emit! ctx (il/call expr-method))
+                 (.CreateType expr-type)
+                 (with-redefs [load (fn magic-load-fn [& paths]
+                                      ;; copied from core.clj
+                                      (doseq [^String path paths]
+                                        (let [^String path (if (.StartsWith path "/")
+                                                             path
+                                                             (str (root-directory (ns-name *ns*)) \/ path))]
+                                          (check-cyclic-dependency path)
+                                          (when-not (= path (first *pending-paths*))
+                                            (binding [*pending-paths* (conj *pending-paths* path)]
+                                              (let [path (.Substring path 1)]
+                                                ;; cant with-redefs because clojure.core/load bottoms out in
+                                                ;; clojure.lang.RT/load
+                                                (if-let [path' (find-file roots path)]
+                                                  (compile-file roots path' path)
+                                                  (throw (Exception. (str "Could not find " path ", roots " roots))))))))))]
+                   (.Invoke (.GetMethod expr-type "eval") nil empty-args))
+                 (recur (read-1) (inc i))))
+             (.Close rdr))))
+       (finally
+         (.Close file))))))
 
 (defn load-assembly
   [path]
@@ -180,54 +183,60 @@
 (def ^:dynamic *write-files* true)
 
 (defn compile-file
-  [roots path module]
-  (println "[compile-file] start" path)
-  (let [module-name (-> module
-                        str
-                        (string/replace "/" ".")
-                        (str ".clj"))]
-    (if (and (not *recompile-namespaces*)
-             (System.IO.File/Exists (str module-name ".dll")))
-      (do
-        (clojure.lang.RT/load (str module))
-        (println "[compile-file] end" path "(skipped, module already exists, loaded instead)"))
-      (binding [*print-meta* false
-                *ns* *ns*
-                magic.emission/*module* (magic.emission/fresh-module module-name)]
-        (let [type-name (clojure-clr-init-class-name module)
-              ns-type (.DefineType magic.emission/*module* type-name abstract-sealed)
-              init-method (.DefineMethod ns-type "Initialize" public-static)
-              init-ilg (.GetILGenerator init-method)
-              ctx {::il/module-builder magic.emission/*module*
-                   ::il/type-builder ns-type
-                   ::il/method-builder init-method
-                   ::il/ilg init-ilg}]
-          ;; TODO this is becoming a mess -- normalize paths in one place
-          (if (System.IO.File/Exists path)
-            (load-file roots path ctx)
-            (if-let [path (find-file roots path)]
-              (load-file roots path ctx)
-              (throw (Exception. (str "Could not find " path ", roots " roots)))))
-          (il/emit! ctx (il/ret))
-          (.CreateType ns-type))
-        (when *write-files*
-         (.. magic.emission/*module* Assembly (Save (.Name magic.emission/*module*))))
-        (println "[compile-file] end" path "->" (.Name magic.emission/*module*))))))
+  ([roots path module]
+   (compile-file roots path module nil))
+  ([roots path module opts]
+   (println "[compile-file] start" path)
+   (let [module-name (-> module
+                         str
+                         (string/replace "/" ".")
+                         (str ".clj"))]
+     (if (and (not *recompile-namespaces*)
+              (System.IO.File/Exists (str module-name ".dll")))
+       (do
+         (clojure.lang.RT/load (str module))
+         (println "[compile-file] end" path "(skipped, module already exists, loaded instead)"))
+       (binding [*print-meta* false
+                 *ns* *ns*
+                 magic.emission/*module* (magic.emission/fresh-module module-name)]
+         (let [type-name (clojure-clr-init-class-name module)
+               ns-type (.DefineType magic.emission/*module* type-name abstract-sealed)
+               init-method (.DefineMethod ns-type "Initialize" public-static)
+               init-ilg (.GetILGenerator init-method)
+               ctx {::il/module-builder magic.emission/*module*
+                    ::il/type-builder ns-type
+                    ::il/method-builder init-method
+                    ::il/ilg init-ilg}]
+           ;; TODO this is becoming a mess -- normalize paths in one place
+           (if (System.IO.File/Exists path)
+             (load-file roots path ctx opts)
+             (if-let [path (find-file roots path)]
+               (load-file roots path ctx opts)
+               (throw (Exception. (str "Could not find " path ", roots " roots)))))
+           (il/emit! ctx (il/ret))
+           (.CreateType ns-type))
+         (when *write-files*
+           (.. magic.emission/*module* Assembly (Save (.Name magic.emission/*module*))))
+         (println "[compile-file] end" path "->" (.Name magic.emission/*module*)))))))
 
 (def load-one' (deref (clojure.lang.RT/var "clojure.core" "load-one")))
 (def -loaded-libs (deref (clojure.lang.RT/var "clojure.core" "*loaded-libs*")))
 
 (defn compile-namespace
-  [roots namespace]
-  (println "[compile-namespace]" namespace)
-  (when-let [path (find-file roots namespace)]
-    (with-redefs [clojure.core/load-one (fn magic-load-one-fn [lib need-ns require]
-                                          (println "  [load-one]" lib need-ns require (type -loaded-libs) (deref -loaded-libs))
-                                          (binding [*ns* *ns*]
-                                            (compile-namespace roots lib)
-                                            (dosync
-                                             (commute -loaded-libs conj lib))))]
-      (compile-file roots path (munge (str namespace))))))
+  "Keys in opts:
+  :suppress-print-forms - if logical true, suppresses printing each compiled form"
+  ([roots namespace]
+   (compile-namespace roots namespace nil))
+  ([roots namespace opts]
+   (println "[compile-namespace]" namespace)
+   (when-let [path (find-file roots namespace)]
+     (with-redefs [clojure.core/load-one (fn magic-load-one-fn [lib need-ns require]
+                                           (println "[load-one]" lib need-ns require (type -loaded-libs) (deref -loaded-libs))
+                                           (binding [*ns* *ns*]
+                                             (compile-namespace roots lib opts)
+                                             (dosync
+                                               (commute -loaded-libs conj lib))))]
+       (compile-file roots path (munge (str namespace)))))))
 
 (def version "0.0-alpha")
 


### PR DESCRIPTION
`:suppress-print-forms` suppresses printout of each compiled form.

Preserves signature for previous invocation sites and adds the optional (off by default) ability to suppress printing every form, which can add significantly to compilation time and spam the REPL.