### PR TITLE
Setup a github workflow on push actions that generates latest magic dlls

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,105 @@
+name: .NET
+
+# This script achieves the MAGIC compiler boostrappping and stores the new assemblies in a github artifact
+# the DLLs will be accessible for 90 days upon build date.
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    # Get current branch name
+    - name: Get branch name (merge)
+      if: github.event_name != 'pull_request'
+      shell: bash
+      run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+
+    - name: Get branch name (pull request)
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+
+    # Setup .Net
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+
+    # Checkout github repos
+    - name: Checkout Clojure.Runtime
+      uses: actions/checkout@v2
+      with:
+        repository: nasser/Clojure.Runtime
+        path: ./Clojure.Runtime
+
+    - name: Checkout Nostrand
+      uses: actions/checkout@v2
+      with:
+        repository: nasser/nostrand
+        path: ./nostrand
+
+    - name: Checkout Magic
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.BRANCH_NAME }}
+        path: ./magic
+
+    # Build Clojure.Runtime
+    - name: Generate Clojure.Runtime assemblies
+      run: |
+        cd Clojure.Runtime/
+        dotnet build
+
+    # Build Clojure.Runtime inside magic folder
+    - name: Generate Clojure.Runtime assemblies of magic
+      run: |
+        cd magic/Magic.Runtime/
+        dotnet build
+
+    # Build Magic with Nostrand repo DLLs (old Dlls)
+    - name: Build Nostrand
+      run: |
+        cd nostrand/
+        dotnet build
+
+    # Compile magic to dll with old Nostrand version
+    - name: Compile Magic using Nostrand
+      run: |
+        cd magic/
+        dotnet "../nostrand/bin/x64/Debug/net5.0/Nostrand.dll" "build/bootstrap"
+    
+    # Copy Magic dll to nostrand
+    - name: Copy new Magic dlls in bootstrap to Nostrand reference
+      run: |
+        if [ -d "/magic/bootstrap" ] 
+        then
+        cp magic/bootstrap/* nostrand/references/
+        fi
+        cp Clojure.Runtime/bin/Debug/netstandard2.0/* nostrand/references-netstandard/
+        cp Clojure.Runtime/bin/Debug/net40/* nostrand/references-net4x/
+        cp magic/Magic.Runtime/bin/Debug/netstandard2.0/* nostrand/references-netstandard/
+        cp magic/Magic.Runtime/bin/Debug/net461/* nostrand/references-net4x/
+
+    # Rebuild Nostrand using the new magic DLLs
+    - name: Rebuild Nostrand (with new Magic dlls)
+      run: |
+        cd nostrand/
+        dotnet build
+
+    # Compile magic to dll with new nostrand (self-hosting cycle complete)
+    - name: Recompile Magic with the new Nostrand version
+      run: |
+        cd magic/
+        rm -rf bootstrap/
+        dotnet "../nostrand/bin/x64/Debug/net5.0/Nostrand.dll" "build/bootstrap"
+
+   # Store the bootstrap folder with the new assemblies as artifact for 90 days
+    - name: Store new DLLs as a github artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: magic-assemblies
+        path: ./magic/bootstrap

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,7 @@
 name: .NET
 
 # This script achieves the MAGIC compiler boostrappping and stores the new assemblies in a github artifact
-# the DLLs will be accessible for 90 days upon build date.
+# The DLLs will be accessible for 90 days upon build date.
 
 on: [push]
 
@@ -53,24 +53,21 @@ jobs:
       run: |
         cd Clojure.Runtime/
         dotnet build
-
     # Build Clojure.Runtime inside magic folder
     - name: Generate Clojure.Runtime assemblies of magic
       run: |
         cd magic/Magic.Runtime/
         dotnet build
-
     # Build Magic with Nostrand repo DLLs (old Dlls)
     - name: Build Nostrand
       run: |
         cd nostrand/
         dotnet build
-
     # Compile magic to dll with old Nostrand version
     - name: Compile Magic using Nostrand
       run: |
         cd magic/
-        dotnet "../nostrand/bin/x64/Debug/net5.0/Nostrand.dll" "build/bootstrap"
+        mono "../nostrand/bin/x64/Debug/net471/Nostrand.exe" "build/bootstrap"
     
     # Copy Magic dll to nostrand
     - name: Copy new Magic dlls in bootstrap to Nostrand reference
@@ -83,20 +80,17 @@ jobs:
         cp Clojure.Runtime/bin/Debug/net40/* nostrand/references-net4x/
         cp magic/Magic.Runtime/bin/Debug/netstandard2.0/* nostrand/references-netstandard/
         cp magic/Magic.Runtime/bin/Debug/net461/* nostrand/references-net4x/
-
     # Rebuild Nostrand using the new magic DLLs
     - name: Rebuild Nostrand (with new Magic dlls)
       run: |
         cd nostrand/
         dotnet build
-
     # Compile magic to dll with new nostrand (self-hosting cycle complete)
     - name: Recompile Magic with the new Nostrand version
       run: |
         cd magic/
         rm -rf bootstrap/
-        dotnet "../nostrand/bin/x64/Debug/net5.0/Nostrand.dll" "build/bootstrap"
-
+        mono "../nostrand/bin/x64/Debug/net471/Nostrand.exe" "build/bootstrap"
    # Store the bootstrap folder with the new assemblies as artifact for 90 days
     - name: Store new DLLs as a github artifact
       uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ Magic.Unity
 deps
 *.meta
 *.dll
+bootstrap
+temp

--- a/build.clj
+++ b/build.clj
@@ -1,32 +1,32 @@
 (ns build
   (:require [magic.api :as api]
             magic.util
-            files
+            #_files
             [magic.core :refer [*spells*]]
             [magic.spells.sparse-case :refer [sparse-case]]
-            [mage.core :as il]
-            [magic.profiler :refer [profile write-trace!]])
+            #_[mage.core :as il]
+            #_[magic.profiler :refer [profile write-trace!]])
   (:import [System.Reflection MethodAttributes TypeAttributes BindingFlags]
            [System.IO File Directory Path DirectoryInfo]))
 
-(def local-load-paths
-  [files/magic-root
-   files/mage-root
-   files/clojure-root
-   files/analyzer-root
-   (str files/clojure-root "clojure") ;; HACK
-   files/test-root
-   "."
-   "/home/nasser/projects/magic/sandbox"
-   "/home/nasser/projects/magic/datascript/src"
-   "/home/nasser/projects/magic/datascript/test"
-   "/home/nasser/projects/arcadia/Assets/Arcadia/Source/"])
+#_(def local-load-paths
+    [files/magic-root
+     files/mage-root
+     files/clojure-root
+     files/analyzer-root
+     (str files/clojure-root "clojure") ;; HACK
+     files/test-root
+     "."
+     "/home/nasser/projects/magic/sandbox"
+     "/home/nasser/projects/magic/datascript/src"
+     "/home/nasser/projects/magic/datascript/test"
+     "/home/nasser/projects/arcadia/Assets/Arcadia/Source/"])
 
 (defn bootstrap [& opts]
   (let [opts (set opts)]
     (binding [*print-meta* true
               clojure.core/*loaded-libs* (ref (sorted-set))
-              *load-paths* (vec (concat local-load-paths *load-paths*))
+              *load-paths* (vec (concat [] *load-paths*))
               *eval-form-fn* magic.api/eval
               *compile-file-fn* magic.api/runtime-compile-file
               *load-file-fn* magic.api/runtime-load-file
@@ -115,7 +115,7 @@
   (copy-dir "Magic.IL2CPP/bin/Release/net461" "Magic.Unity/Infrastructure/IL2CPP")
   
   ;; build clojure core
-  (build-core)
+  #_(build-core)
   ;; patch clojure core for il2cpp
   (exec "mono" (str "Magic.IL2CPP/bin/Release/net461/Magic.IL2CPP.CLI.exe "
                     (String/Join " " (Directory/EnumerateFiles "." "*.clj.dll"))))


### PR DESCRIPTION
close #211 

This github workflow allows user of the `magic` library to get the latest available `magic` and `stdlib` dlls.

So they can just add them in their `nostrand.references` folder without having to bootstrap magic.
