### PR TITLE
Use .FullName as equivalent of .getName in datafy

### DIFF
--- a/src/stdlib/clojure/datafy.clj
+++ b/src/stdlib/clojure/datafy.clj
@@ -24,7 +24,7 @@
     (if (identical? v x)
       v
       (if (instance? clojure.lang.IObj v)
-        (vary-meta v assoc ::obj x ::class (-> x class str symbol))    ;;; .getName
+        (vary-meta v assoc ::obj x ::class (-> x class .FullName symbol))    ;;; .getName
         v))))
 
 (defn nav
@@ -50,7 +50,7 @@
 
   clojure.lang.Namespace
   (datafy [n]
-          (with-meta {:name (.getName n)
+          (with-meta {:name (.FullName n)                 ;;; .getName
                       :publics (-> n ns-publics sortmap)
                       :imports (-> n ns-imports sortmap)
                       :interns (-> n ns-interns sortmap)}
@@ -59,4 +59,4 @@
   System.Type                                                                                            ;;; java.lang.Class
   (datafy [c]
           (let [{:keys [members] :as ret} ((requiring-resolve 'clojure.reflect/reflect) c)]
-            (assoc ret :name (-> c .Name symbol) :members (->> members (group-by :name) sortmap)))))     ;;; .getName
+            (assoc ret :name (-> c .FullName symbol) :members (->> members (group-by :name) sortmap)))))     ;;; .getName


### PR DESCRIPTION
Closes #235
---

Use `.FullName` instead of `str` or `.Name` as equivalent CLR method for the JVM method `.getName` in `clojure.datafy`
